### PR TITLE
Add a method to create wrappers returning a promise

### DIFF
--- a/bin/build-test.js
+++ b/bin/build-test.js
@@ -7,6 +7,8 @@ const Path = require('path');
         const bundles = {
             "test-class-worker-bundle.js":
                 Path.join("test", "test-class-worker.js"),
+            "test-class-shared-worker-bundle.js":
+                Path.join("test", "test-class-shared-worker.js"),
         };
         await Bundler.build(bundles);
     } catch(err) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 "use strict";
+const assert = require("assert");
 const uuidv4 = require("uuid/v4");
 
 /**
@@ -46,6 +47,60 @@ if(!globalContextName) {
 TransWorker.context = globalContextName;
 
 /**
+ * A literal for the interface methods to synchronize with a callback.
+ * @type {Function}
+ */
+TransWorker.SyncTypeCallback = Function;
+
+/**
+ * A literal for the interface methods to synchronize with a Promise.
+ * @type {Function}
+ */
+TransWorker.SyncTypePromise = Promise;
+
+/**
+ * Options fot a TransWorker object.
+ * @constructor
+ * @param {object} options an option object
+ */
+TransWorker.Options = function(options) {
+    options = options || {
+        shared: false,
+        syncType: TransWorker.SyncTypeCallback,
+    };
+    options.shared = (options.shared != null ? options.shared : false);
+    options.syncType = (options.syncType != null ? options.syncType :
+        TransWorker.SyncTypeCallback);
+    assert.ok(typeof(options.shared) === "boolean" && (
+        options.syncType === TransWorker.SyncTypeCallback ||
+        options.syncType === TransWorker.SyncTypePromise));
+    this.shared = options.shared;
+    this.syncType = options.syncType;
+};
+
+/**
+ * Create a worker and an interface instance for the thread.
+ *
+ * @param {string} workerUrl A worker url. It must use TransWorker.
+ * @param {Function} clientCtor client-class constructor.
+ * @param {TransWorker.Options} options Options to create a wrapper object for
+ *      the main thread.
+ * @returns {Transworker} The created TransWorker instance.
+ */
+TransWorker.createInterface = function(workerUrl, clientCtor, options) {
+    options = options || new TransWorker.Options();
+    if(workerUrl.constructor !== TransWorker.Options) {
+        options = new TransWorker.Options(options);
+    }
+
+    const transworker = new TransWorker();
+    transworker._shared = options.shared;
+    transworker._syncType = options.syncType;
+    transworker.createInvoker(workerUrl, clientCtor);
+    return transworker;
+};
+
+/**
  * Create instance for main thread.
  *
  * @param {string} workerUrl A worker url. It must use TransWorker.
@@ -60,6 +115,7 @@ TransWorker.createInvoker = function(
 {
     const transworker = new TransWorker();
     transworker._shared = false;
+    transworker._syncType = TransWorker.SyncTypeCallback;
     transworker.createInvoker(
         workerUrl, clientCtor,
         thisObject, notifyHandlers);
@@ -81,6 +137,7 @@ TransWorker.createSharedInvoker = function(
 {
     const transworker = new TransWorker();
     transworker._shared = true;
+    transworker._syncType = TransWorker.SyncTypeCallback;
     transworker.createInvoker(
         workerUrl, clientCtor,
         thisObject, notifyHandlers);
@@ -137,15 +194,28 @@ TransWorker.prototype.createInvoker = function(
     if(!this._shared) {
         // Load dedicated worker
         this.worker = new Worker(workerUrl);
-        this.worker.onmessage = onReceiveMessage;
+        this.messagePort = this.worker;
+        this.messagePort.onmessage = onReceiveMessage;
     } else {
         this.worker = new SharedWorker(workerUrl);
-        this.worker.port.onmessage = onReceiveMessage;
-        this.worker.port.start();
+        this.messagePort = this.worker.port;
+        this.messagePort.onmessage = onReceiveMessage;
+        this.messagePort.start();
     }
 
     // Create prototype entries same to the client
-    this.createWrappers(Object.keys(clientCtor.prototype));
+    const methodNames = Object.keys(clientCtor.prototype)
+    if(this._syncType === TransWorker.SyncTypePromise) {
+        for(const methodName of methodNames) {
+            TransWorker.prototype[methodName] =
+                this.createPromiseWrapper(methodName);
+        }
+    } else {
+        for(const methodName of methodNames) {
+            TransWorker.prototype[methodName] =
+                this.createCallbackWrapper(methodName);
+        }
+    }
 
     // Entry the handlers to receive notifies
     notifyHandlers = notifyHandlers || {};
@@ -179,35 +249,22 @@ TransWorker.prototype.subscribe = function(name, handler) {
 };
 
 /**
- * Create wrapper methods to send message to the worker
- * @param {Array<string>} methodNames An array of method names to override.
- * @returns {undefined}
- */
-TransWorker.prototype.createWrappers = function(
-        methodNames)
-{
-    for(const methodName of methodNames) {
-        TransWorker.prototype[methodName] = this.wrapper(methodName);
-    }
-};
-
-/**
  * Create client method wrapper
  * @param {string} methodName A method name to override.
  * @returns {Function} A wrapper function.
  */
-TransWorker.prototype.wrapper = function(
-        methodName)
+TransWorker.prototype.createCallbackWrapper = function(methodName)
 {
-    const port = (this._shared ? this.worker.port : this.worker);
     return (...param) => {
         const queryId = this.queryId++;
+        console.log("*** " + param.length);
+        console.log("*** " + typeof(param.slice(-1)[0]));
         if(param.length > 0 && typeof(param.slice(-1)[0]) === "function") {
             this.callbacks[queryId] = param.splice(-1, 1)[0];
         } else {
             this.callbacks[queryId] = (()=>{});
         }
-        port.postMessage({
+        this.messagePort.postMessage({
             method: methodName,
             param: param,
             uuid: this._uuid,
@@ -216,6 +273,31 @@ TransWorker.prototype.wrapper = function(
     };
 };
 
+/**
+ * Create client method wrapper that returns a promise that will be resolved
+ * by a value that remote method returns.
+ * @param {string} methodName A method name to override.
+ * @returns {Function} A wrapper function.
+ */
+TransWorker.prototype.createPromiseWrapper = function(methodName)
+{
+    return (...param) => {
+        return new Promise((resolve, reject) => {
+            try {
+                const queryId = this.queryId++;
+                this.callbacks[queryId] = (result => resolve(result));
+                this.messagePort.postMessage({
+                    method: methodName,
+                    param: param,
+                    uuid: this._uuid,
+                    queryId: queryId
+                });
+            } catch(err) {
+                reject(err);
+            }
+        });
+    };
+};
 /**
  * Create a Worker side TransWorker instance.
  *
@@ -257,7 +339,7 @@ TransWorker.createSharedWorker = function(client) {
 TransWorker.prototype.createWorker = function(client) {
     this.worker = globalContext;
     this.client = client;
-    this.port = null;
+    this.messagePort = null;
 
     // Make the client to be able to use this module
     this.client._transworker = this;
@@ -284,8 +366,9 @@ TransWorker.prototype.createWorker = function(client) {
     // method and post back its value.
     const onReceiveMessage = (e => {
         try {
+            console.log(`onReceiveMessage: ${JSON.stringify(e.data)}`);
             //return the value to UI-thread
-            this.port.postMessage({
+            this.messagePort.postMessage({
                 type:'response',
                 uuid: e.data.uuid,
                 queryId: e.data.queryId,
@@ -304,13 +387,14 @@ TransWorker.prototype.createWorker = function(client) {
 
     if(this._shared) {
         this.worker.onconnect = e => {
-            this.port = e.ports[0];
-            this.port.addEventListener("message", onReceiveMessage);
-            this.port.start();
+            console.log(`onconnect`);
+            this.messagePort = e.ports[0];
+            this.messagePort.addEventListener("message", onReceiveMessage);
+            this.messagePort.start();
         }
     } else {
-        this.port = this.worker;
-        this.port.onmessage = onReceiveMessage;
+        this.messagePort = this.worker;
+        this.messagePort.onmessage = onReceiveMessage;
     }
 };
 
@@ -323,7 +407,7 @@ TransWorker.prototype.createWorker = function(client) {
 TransWorker.prototype.postNotify = function(
         name, param)
 {
-    this.port.postMessage({
+    this.messagePort.postMessage({
         type:'notify',
         name: name,
         param: param

--- a/test/test-class-shared-worker.js
+++ b/test/test-class-shared-worker.js
@@ -1,0 +1,9 @@
+"use strict"
+require("babel-polyfill");
+const TransWorker = require("../transworker.js");
+const TestClass = require("./test-class.js");
+TestClass.prototype.requestNotify = function(name, message) {
+    console.log(`requestNotify(${name},${message});`);
+    this._transworker.postNotify(name, message);
+};
+TransWorker.createSharedWorker(TestClass);

--- a/test/test.html
+++ b/test/test.html
@@ -21,6 +21,9 @@
 <!-- テストスクリプトを読み込む -->
 <script src="./babel-polyfill.js"></script>
 <script src="./transworker.js"></script>
+<script src="./transworker-create-shared-invoker.js"></script>
+<script src="./transworker-create-interface.js"></script>
+<script src="./transworker-options.js"></script>
 
 <!-- テストの実行 -->
 <script>

--- a/test/transworker-create-interface.js
+++ b/test/transworker-create-interface.js
@@ -1,0 +1,96 @@
+"use strict"
+const assert = require("chai").assert;
+const TransWorker = require("../index.js");
+const TestClass = require("./test-class.js");
+describe("TransWorker", () => {
+    describe("createInterface", () => {
+        describe("without options", () => {
+            it("should creates DedicatedWorker", () => {
+                const tw = TransWorker.createInterface(
+                    "test-class-worker-bundle.js", TestClass);
+                assert.isFalse(tw._shared);
+            });
+            it("should creates wrappers that is resolved by callback", () => {
+                const tw = TransWorker.createInterface(
+                    "test-class-worker-bundle.js", TestClass);
+                assert.equal(tw._syncType, Function);
+            });
+        });
+        it("should creates DedicatedWorker specified by options", () => {
+            const tw = TransWorker.createInterface(
+                "test-class-worker-bundle.js", TestClass,
+                { shared: false }
+            );
+            assert.isFalse(tw._shared);
+            assert.equal(tw._syncType, Function);
+        });
+        it("should creates SharedWorker specified by options", () => {
+            const tw = TransWorker.createInterface(
+                "test-class-shared-worker-bundle.js", TestClass,
+                { shared: true }
+            );
+            assert.isTrue(tw._shared);
+            assert.equal(tw._syncType, Function);
+        });
+        it("should creates DedicatedWorker resolved by Callback", () => {
+            const tw = TransWorker.createInterface(
+                "test-class-worker-bundle.js", TestClass,
+                { syncType: TransWorker.SyncTypeCallback }
+            );
+            assert.isFalse(tw._shared);
+            assert.equal(tw._syncType, TransWorker.SyncTypeCallback);
+        });
+        it("should creates DedicatedWorker resolved by Promise", () => {
+            const tw = TransWorker.createInterface(
+                "test-class-worker-bundle.js", TestClass,
+                { syncType: TransWorker.SyncTypePromise }
+            );
+            assert.isFalse(tw._shared);
+            assert.equal(tw._syncType, TransWorker.SyncTypePromise);
+        });
+        it("should creates SharedWorker and Promise wrappers with options", () => {
+            const tw = TransWorker.createInterface(
+                "test-class-shared-worker-bundle.js", TestClass, {
+                    shared: true,
+                    syncType: TransWorker.SyncTypePromise,
+                }
+            );
+            assert.isTrue(tw._shared);
+            assert.equal(tw._syncType, Promise);
+        });
+        describe("syncType = Promise", () => {
+            it("should create a wrapper that returns promise", () => {
+                assert.doesNotThrow(() => {
+                    const tw = TransWorker.createInterface(
+                        "test-class-worker-bundle.js", TestClass,
+                        { syncType: TransWorker.SyncTypePromise });
+                    assert.equal(tw.testMethod().constructor, Promise);
+                });
+            });
+            it("should callback a return value", async () => {
+                try {
+                    const tw = TransWorker.createInterface(
+                        "/test-class-worker-bundle.js", TestClass,
+                        { syncType: TransWorker.SyncTypePromise });
+                    assert.equal(await tw.testMethod(), "TestClass.testMethod");
+                } catch (err) {
+                    assert.fail(err.message);
+                }
+            });
+            it("should transport all parameters to worker even if the callback is omitted (issue#14)", async () => {
+                try {
+                    const result = await new Promise( resolve => {
+                        const tw = TransWorker.createInterface(
+                            "/test-class-worker-bundle.js", TestClass, null,
+                            { syncType: TransWorker.SyncTypePromise });
+                        tw.subscribe("hello", message => resolve(message));
+                        tw.requestNotify("hello", "transworker");
+                    });
+                    assert.equal(result, "transworker");
+                } catch (err) {
+                    assert.fail(err.message);
+                }
+            });
+        });
+    });
+});

--- a/test/transworker-create-shared-invoker.js
+++ b/test/transworker-create-shared-invoker.js
@@ -1,0 +1,68 @@
+"use strict"
+const assert = require("chai").assert;
+const TransWorker = require("../index.js");
+const TestClass = require("./test-class.js");
+describe("TransWorker", () => {
+    describe("createSharedInvoker", () => {
+        it("should override target class prototype", () => {
+            const tw = TransWorker.createSharedInvoker(
+                "test-class-worker-bundle.js", TestClass);
+            assert.isTrue("testMethod" in tw);
+        });
+        it("should declare a function of target class prototype", () => {
+            const tw = TransWorker.createSharedInvoker(
+                "test-class-worker-bundle.js", TestClass);
+            assert.equal(typeof(tw.testMethod), "function");
+        });
+        it("should create a dedicated worker", () => {
+            const tw = TransWorker.createSharedInvoker(
+                "test-class-worker-bundle.js", TestClass);
+            assert.isNotNull(tw.worker);
+        });
+        describe("The wrapper methods behavior", () => {
+            describe("Normally invocation", () => {
+                it("should be invoked when the callback is specified", () => {
+                    assert.doesNotThrow(() => {
+                        const tw = TransWorker.createSharedInvoker(
+                            "test-class-worker-bundle.js", TestClass);
+                        tw.testMethod(() => {});
+                    });
+                });
+                it("should be invoked when the callback is not specified", () => {
+                    assert.doesNotThrow(() => {
+                        const tw = TransWorker.createSharedInvoker(
+                            "test-class-worker-bundle.js", TestClass);
+                        tw.testMethod();
+                    });
+                });
+            });
+            describe("The return value", () => {
+                it("should callback a return value", async () => {
+                    try {
+                        const tw = TransWorker.createSharedInvoker(
+                            "/test-class-shared-worker-bundle.js", TestClass);
+                        const result = await new Promise(
+                            resolve => tw.testMethod(s => resolve(s)));
+                        assert.equal(result, "TestClass.testMethod");
+                    } catch (err) {
+                        assert.fail(err.message);
+                    }
+                });
+                it("should transport all parameters to worker even if the callback is omitted (issue#14)", async () => {
+                    try {
+                        const result = await new Promise(resolve => {
+                            const tw = TransWorker.createSharedInvoker(
+                                "/test-class-shared-worker-bundle.js", TestClass, null,
+                                { "hello": message => resolve(message) });
+                            tw.requestNotify("hello", "transworker");
+                        });
+                        assert.equal(result, "transworker");
+                    } catch (err) {
+                        assert.fail(err.message);
+                    }
+                });
+            });
+        });
+    });
+});
+

--- a/test/transworker-options.js
+++ b/test/transworker-options.js
@@ -1,0 +1,70 @@
+"use strict"
+const assert = require("chai").assert;
+const TransWorker = require("../index.js");
+describe("TransWorker.Options", () => {
+    describe("constructor", () => {
+        it("should create no-shared when the param is omitted", ()=>{
+            const opt = new TransWorker.Options();
+            assert.isFalse(opt.shared);
+            assert.equal(opt.syncType, TransWorker.SyncTypeCallback);
+        });
+        it("should create sync with callback when the param is omitted", ()=>{
+            const opt = new TransWorker.Options();
+            assert.isFalse(opt.shared);
+            assert.equal(opt.syncType, TransWorker.SyncTypeCallback);
+        });
+        it("should create no-shared when only 'shared' is specified", ()=>{
+            const opt = new TransWorker.Options({shared: false});
+            assert.isFalse(opt.shared);
+            assert.equal(opt.syncType, TransWorker.SyncTypeCallback);
+        });
+        it("should create sync with callback when only 'syncType' is specified", ()=>{
+            const opt = new TransWorker.Options({
+                syncType: TransWorker.SyncTypeCallback,
+            });
+            assert.isFalse(opt.shared);
+            assert.equal(opt.syncType, TransWorker.SyncTypeCallback);
+        });
+        it("should create shared when only 'shared' is specified", ()=>{
+            const opt = new TransWorker.Options({shared: true});
+            assert.isTrue(opt.shared);
+            assert.equal(opt.syncType, TransWorker.SyncTypeCallback);
+        });
+        it("should create sync with promise when only 'syncType' is specified", ()=>{
+            const opt = new TransWorker.Options({
+                syncType: TransWorker.SyncTypePromise,
+            });
+            assert.isFalse(opt.shared);
+            assert.equal(opt.syncType, TransWorker.SyncTypePromise);
+        });
+        describe("Invalid shared option", ()=>{
+            it("should throw when 'shared' is string", ()=>{
+                assert.throw(() => (new TransWorker.Options({ shared: "shared" })));
+            });
+            it("should throw when 'shared' is number", ()=>{
+                assert.throw(() => (new TransWorker.Options({ shared: 0 })));
+            });
+            it("should throw when 'shared' is object", ()=>{
+                assert.throw(() => (new TransWorker.Options({ shared: {} })));
+            });
+            it("should throw when 'shared' is function", ()=>{
+                assert.throw(() => (new TransWorker.Options({ shared: ()=>{} })));
+            });
+        });
+        describe("Invalid syncType option", ()=>{
+            it("should throw when 'syncType' is string", ()=>{
+                assert.throw(() => (new TransWorker.Options({ syncType: "shared" })));
+            });
+            it("should throw when 'syncType' is number", ()=>{
+                assert.throw(() => (new TransWorker.Options({ syncType: 0 })));
+            });
+            it("should throw when 'syncType' is object", ()=>{
+                assert.throw(() => (new TransWorker.Options({ syncType: {} })));
+            });
+            it("should throw when 'syncType' is boolean", ()=>{
+                assert.throw(() => (new TransWorker.Options({ syncType: true })));
+            });
+        });
+    });
+});
+

--- a/test/transworker.js
+++ b/test/transworker.js
@@ -3,8 +3,8 @@ const assert = require("chai").assert;
 const TransWorker = require("../index.js");
 const TestClass = require("./test-class.js");
 describe("TransWorker", () => {
-    describe("Instance in the main thread", () => {
-        describe("createInvoker", () => {
+    describe("createInvoker", () => {
+        describe("Method type", () => {
             it("should override target class prototype", () => {
                 const tw = TransWorker.createInvoker(
                     "test-class-worker-bundle.js", TestClass);
@@ -21,7 +21,7 @@ describe("TransWorker", () => {
                 assert.isNotNull(tw.worker);
             });
         });
-        describe("The wrapper methods created by createInvoker", () => {
+        describe("The wrappers are invokable", () => {
             it("should be invoked when the callback is specified", () => {
                 assert.doesNotThrow(() => {
                     const tw = TransWorker.createInvoker(


### PR DESCRIPTION
The static `TransWorker.createInterface` method is available to create an instance.
It yields wrappers that returns a Promise object instead of what synchronizing by callback function.
And it can also create wrappers for `SharedWoker`.